### PR TITLE
Fix minimize-on-close for TB 52 on Linux

### DIFF
--- a/chrome/content/messenger/messenger.js
+++ b/chrome/content/messenger/messenger.js
@@ -41,6 +41,9 @@ addEventListener(
               event.stopPropagation();
               return false;
             }
+            if (event.type == "close") {
+              return true;
+            }
             // must be in sync with the original command
             return goQuitApplication();
           }
@@ -72,6 +75,7 @@ addEventListener(
           }
           ['titlebar-close'].forEach(hijackButton.bind(null, MinTrayRTryCloseWindow));
           ['titlebar-min'].forEach(hijackButton.bind(null, MinTrayRTryMinimizeWindow));
+          window.addEventListener("close", MinTrayRTryCloseWindow);
         })(this);
 
         this.cloneToMenu('MinTrayR_sep-top', [menu_NewPopup_id, "button-getAllNewMsg", "addressBook"], false);

--- a/install.rdf
+++ b/install.rdf
@@ -19,6 +19,7 @@
     <em:contributor>Mook</em:contributor>
     <em:contributor>helix400</em:contributor>
     <em:contributor>Christoph Grimmer</em:contributor>
+    <em:contributor>rsjtdrjgfuzkfg</em:contributor>
 
     <em:homepageURL>https://github.com/Croydon/mintray-reloaded</em:homepageURL>
     <em:optionsURL>chrome://mintrayr/content/prefs/prefs.xul</em:optionsURL>


### PR DESCRIPTION
@rsjtdrjgfuzkfg

This commit uses the close event handler in addition to existing code,
in order to properly suppress the window close event if closed through
the window manager. I'm unsure how the mechanism was intended to work,
so I left existing code in place although I assume that the existing
window close handler could get removed now.